### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ KeyCastr, an open-source keystroke visualizer.
 ### Installation via [homebrew](http://brew.sh/) [cask](https://github.com/caskroom/homebrew-cask)
 
 ```console
-which cask || brew tap caskroom/cask # Get cask if you don't already have it
-brew cask install keycastr
+brew tap homebrew/cask # Get cask if you don't already have it
+brew install keycastr
 ```
 
 ## History


### PR DESCRIPTION
I'm on MacOS Catalina and Homebrew 3.0.3. The current installation documentation doesn't work as intended.

When running `brew tap caskroom/cask` the following error is thrown:
```
Error: caskroom/cask was moved. Tap homebrew/cask instead.
```
And with the command `brew cask install keycastr` the error thrown is
```
Unknown command: cask
```
Even after adding `homebrew/cask` the `which cask` command fails.

The udpated commands in the PR work correctly.